### PR TITLE
feat: TextHighlight コンポーネントを追加 (#50)

### DIFF
--- a/app/components/AboutSection.tsx
+++ b/app/components/AboutSection.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import TextHighlight from './TextHighlight';
 
 interface TimelineItem {
   year: string;
@@ -66,17 +67,17 @@ export default function AboutSection() {
               </h3>
               <div className="space-y-4 text-gray-700 dark:text-gray-300 leading-relaxed">
                 <p>
-                  こんにちは！私は Web 開発に情熱を持つフルスタックデベロッパーです。
+                  こんにちは！私は Web 開発に情熱を持つ<TextHighlight>フルスタックデベロッパー</TextHighlight>です。
                   ユーザーにとって価値のあるプロダクトを作ることを最も大切にしています。
                 </p>
                 <p>
-                  <strong>フロントエンド</strong>では Next.js、React、TypeScript を使ったモダンな開発を得意としています。
+                  <TextHighlight variant="background">フロントエンド</TextHighlight>では <TextHighlight>Next.js</TextHighlight>、<TextHighlight>React</TextHighlight>、<TextHighlight>TypeScript</TextHighlight> を使ったモダンな開発を得意としています。
                   アクセシビリティ（WCAG 2.1 準拠）やパフォーマンス最適化にも注力しています。
-                  <strong>バックエンド</strong>では Go を使った API 開発の経験があります。
+                  <TextHighlight variant="background">バックエンド</TextHighlight>では <TextHighlight>Go</TextHighlight> を使った API 開発の経験があります。
                 </p>
                 <p>
                   常に新しい技術をキャッチアップし、ベストプラクティスに沿ったコードを書くことを心がけています。
-                  チーム開発や OSS への貢献にも積極的に取り組んでいきたいと考えています。
+                  チーム開発や <TextHighlight>OSS への貢献</TextHighlight>にも積極的に取り組んでいきたいと考えています。
                 </p>
               </div>
             </div>

--- a/app/components/TextHighlight.tsx
+++ b/app/components/TextHighlight.tsx
@@ -1,0 +1,20 @@
+interface TextHighlightProps {
+  children: React.ReactNode;
+  variant?: 'gradient' | 'underline' | 'background';
+}
+
+export default function TextHighlight({
+  children,
+  variant = 'gradient',
+}: TextHighlightProps) {
+  const variants = {
+    gradient:
+      'text-transparent bg-clip-text bg-gradient-to-r from-blue-500 via-purple-500 to-pink-500 font-semibold',
+    underline:
+      'underline decoration-2 decoration-blue-500 underline-offset-4 font-semibold',
+    background:
+      'bg-blue-100 dark:bg-blue-900/50 px-1 rounded font-semibold',
+  };
+
+  return <span className={variants[variant]}>{children}</span>;
+}


### PR DESCRIPTION
## Summary
- キーワードをハイライト表示するコンポーネントを追加
- 3つのバリエーション: gradient, underline, background
- AboutSection に適用

## Changes
- `app/components/TextHighlight.tsx` - 新規作成
- `app/components/AboutSection.tsx` - TextHighlight を使用

## Test plan
- [ ] `npm run build` 成功
- [ ] AboutSection でハイライトが表示されることを確認

Closes #50