### PR TITLE
feat: トースト通知コンポーネントを追加 (#49)

### DIFF
--- a/app/components/ToastProvider.tsx
+++ b/app/components/ToastProvider.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import { Toaster } from 'react-hot-toast';
+
+export default function ToastProvider() {
+  return (
+    <Toaster
+      position="bottom-right"
+      toastOptions={{
+        duration: 4000,
+        style: {
+          background: '#333',
+          color: '#fff',
+        },
+        success: {
+          style: {
+            background: '#10b981',
+          },
+          iconTheme: {
+            primary: '#fff',
+            secondary: '#10b981',
+          },
+        },
+        error: {
+          style: {
+            background: '#ef4444',
+          },
+          iconTheme: {
+            primary: '#fff',
+            secondary: '#ef4444',
+          },
+        },
+      }}
+    />
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,7 @@ import { Noto_Sans_JP } from "next/font/google";
 import "./globals.css";
 import SkipLink from "./components/SkipLink";
 import Navigation from "./components/Navigation";
+import ToastProvider from "./components/ToastProvider";
 
 const notoSansJP = Noto_Sans_JP({
   subsets: ["latin"],
@@ -67,6 +68,7 @@ export default function RootLayout({
         <SkipLink />
         <Navigation />
         {children}
+        <ToastProvider />
       </body>
     </html>
   );

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "next": "^15.1.5",
         "react": "^19.0.0",
-        "react-dom": "^19.0.0"
+        "react-dom": "^19.0.0",
+        "react-hot-toast": "^2.6.0"
       },
       "devDependencies": {
         "@types/node": "^22",
@@ -2246,7 +2247,6 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -3394,6 +3394,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/goober": {
+      "version": "2.1.18",
+      "resolved": "https://registry.npmjs.org/goober/-/goober-2.1.18.tgz",
+      "integrity": "sha512-2vFqsaDVIT9Gz7N6kAL++pLpp41l3PfDuusHcjnGLfR6+huZkl6ziX+zgVC3ZxpqWhzH6pyDdGrCeDhMIvwaxw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "csstype": "^3.0.10"
       }
     },
     "node_modules/gopd": {
@@ -4937,6 +4946,23 @@
       },
       "peerDependencies": {
         "react": "^19.2.3"
+      }
+    },
+    "node_modules/react-hot-toast": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/react-hot-toast/-/react-hot-toast-2.6.0.tgz",
+      "integrity": "sha512-bH+2EBMZ4sdyou/DPrfgIouFpcRLCJ+HoCA32UoAYHn6T3Ur5yfcDCeSr5mwldl6pFOsiocmrXMuoCJ1vV8bWg==",
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.1.3",
+        "goober": "^2.1.16"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">=16",
+        "react-dom": ">=16"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   "dependencies": {
     "next": "^15.1.5",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "react-hot-toast": "^2.6.0"
   },
   "devDependencies": {
     "@types/node": "^22",


### PR DESCRIPTION
## Summary
- react-hot-toast を導入
- ToastProvider コンポーネントを追加してレイアウトに組み込み

## Usage
\`\`\`tsx
import toast from 'react-hot-toast';

toast.success('送信しました');
toast.error('エラーが発生しました');
\`\`\`

## Changes
- `app/components/ToastProvider.tsx` - 新規作成
- `app/layout.tsx` - ToastProvider を追加

## Test plan
- [ ] `npm run build` 成功

Closes #49