### PR TITLE
feat: react-icons を導入 (#36)

### DIFF
--- a/app/components/ContactSection.tsx
+++ b/app/components/ContactSection.tsx
@@ -1,6 +1,8 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import { FaGithub } from 'react-icons/fa';
+import { HiOutlineMail, HiArrowRight } from 'react-icons/hi';
 
 interface ContactLink {
   name: string;
@@ -19,31 +21,13 @@ export default function ContactSection() {
   const contactLinks: ContactLink[] = [
     {
       name: 'GitHub',
-      icon: (
-        <svg className="w-8 h-8" fill="currentColor" viewBox="0 0 24 24">
-          <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
-        </svg>
-      ),
+      icon: <FaGithub className="w-8 h-8" />,
       url: 'https://github.com/TadokoroYuki',
       label: '@TadokoroYuki',
     },
     {
       name: 'Email',
-      icon: (
-        <svg
-          className="w-8 h-8"
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke="currentColor"
-        >
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeWidth={2}
-            d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"
-          />
-        </svg>
-      ),
+      icon: <HiOutlineMail className="w-8 h-8" />,
       url: 'mailto:tdkryk@icloud.com',
       label: 'tdkryk@icloud.com',
     },
@@ -100,19 +84,7 @@ export default function ContactSection() {
                     </p>
                   </div>
                   <div className="flex-shrink-0">
-                    <svg
-                      className="w-5 h-5 text-gray-400 group-hover:text-blue-600 dark:group-hover:text-blue-400 transition-colors"
-                      fill="none"
-                      viewBox="0 0 24 24"
-                      stroke="currentColor"
-                    >
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        strokeWidth={2}
-                        d="M14 5l7 7m0 0l-7 7m7-7H3"
-                      />
-                    </svg>
+                    <HiArrowRight className="w-5 h-5 text-gray-400 group-hover:text-blue-600 dark:group-hover:text-blue-400 transition-colors" />
                   </div>
                 </div>
               </a>

--- a/app/components/ProjectsSection.tsx
+++ b/app/components/ProjectsSection.tsx
@@ -1,6 +1,8 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import { FaGithub } from 'react-icons/fa';
+import { HiOutlineExternalLink, HiOutlinePhotograph } from 'react-icons/hi';
 
 interface Project {
   title: string;
@@ -65,19 +67,7 @@ export default function ProjectsSection() {
               >
                 {/* Project Image Placeholder */}
                 <div className="h-48 bg-gradient-to-br from-blue-500 to-purple-600 flex items-center justify-center">
-                  <svg
-                    className="w-16 h-16 text-white opacity-50"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    stroke="currentColor"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={2}
-                      d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"
-                    />
-                  </svg>
+                  <HiOutlinePhotograph className="w-16 h-16 text-white opacity-50" />
                 </div>
 
                 {/* Project Content */}
@@ -110,13 +100,7 @@ export default function ProjectsSection() {
                         rel="noopener noreferrer"
                         className="flex items-center gap-2 text-gray-700 dark:text-gray-300 hover:text-blue-600 dark:hover:text-blue-400 transition-colors"
                       >
-                        <svg
-                          className="w-5 h-5"
-                          fill="currentColor"
-                          viewBox="0 0 24 24"
-                        >
-                          <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
-                        </svg>
+                        <FaGithub className="w-5 h-5" />
                         <span className="text-sm font-medium">Code</span>
                       </a>
                     )}
@@ -127,19 +111,7 @@ export default function ProjectsSection() {
                         rel="noopener noreferrer"
                         className="flex items-center gap-2 text-gray-700 dark:text-gray-300 hover:text-blue-600 dark:hover:text-blue-400 transition-colors"
                       >
-                        <svg
-                          className="w-5 h-5"
-                          fill="none"
-                          viewBox="0 0 24 24"
-                          stroke="currentColor"
-                        >
-                          <path
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                            strokeWidth={2}
-                            d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"
-                          />
-                        </svg>
+                        <HiOutlineExternalLink className="w-5 h-5" />
                         <span className="text-sm font-medium">Demo</span>
                       </a>
                     )}

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-hot-toast": "^2.6.0",
+        "react-icons": "^5.5.0",
         "react-type-animation": "^3.2.0"
       },
       "devDependencies": {
@@ -4118,6 +4119,15 @@
       "peerDependencies": {
         "react": ">=16",
         "react-dom": ">=16"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.5.0.tgz",
+      "integrity": "sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-hot-toast": "^2.6.0",
+    "react-icons": "^5.5.0",
     "react-type-animation": "^3.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- react-icons を導入
- インラインSVGをreact-iconsに置換

## Changes
- `app/components/ContactSection.tsx` - FaGithub, HiOutlineMail, HiArrowRight
- `app/components/ProjectsSection.tsx` - FaGithub, HiOutlineExternalLink, HiOutlinePhotograph

## Benefits
- コードの可読性向上
- メンテナンス性向上
- 一貫したアイコンスタイル

## Test plan
- [ ] `npm run build` 成功
- [ ] アイコンが正しく表示されることを確認

Closes #36