### PR TITLE
feat: サイトマップ自動生成の実装

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,7 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# sitemap (generated at build time)
+public/sitemap*.xml
+public/robots.txt

--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -1,0 +1,16 @@
+/** @type {import('next-sitemap').IConfig} */
+module.exports = {
+  siteUrl: process.env.SITE_URL || 'https://your-portfolio.vercel.app',
+  generateRobotsTxt: true,
+  sitemapSize: 7000,
+  changefreq: 'monthly',
+  priority: 0.7,
+  robotsTxtOptions: {
+    policies: [
+      {
+        userAgent: '*',
+        allow: '/',
+      },
+    ],
+  },
+};

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
+    "postbuild": "next-sitemap",
     "start": "next start",
     "lint": "next lint",
     "format": "prettier --write .",
@@ -25,6 +26,7 @@
     "autoprefixer": "^10.4.20",
     "eslint": "^9",
     "eslint-config-next": "^15.1.5",
+    "next-sitemap": "^4.2.3",
     "postcss": "^8.4.49",
     "prettier": "^3.8.1",
     "tailwindcss": "^3.4.17",


### PR DESCRIPTION
## Summary
- next-sitemapパッケージを導入し、ビルド時にサイトマップを自動生成
- sitemap.xmlとrobots.txtがビルド時に自動生成される
- 生成ファイルはビルド時に都度生成されるため.gitignoreに追加

## Test plan
- [ ] `npm run build`実行後、`public/sitemap.xml`が生成されることを確認
- [ ] `public/robots.txt`が生成されることを確認
- [ ] サイトマップの内容が正しいことを確認

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)