### PR TITLE
feat: 背景パーティクルアニメーションの実装

### DIFF
--- a/app/components/HeroSection.tsx
+++ b/app/components/HeroSection.tsx
@@ -5,6 +5,7 @@ import Image from 'next/image';
 import { motion, useReducedMotion, type Variants } from 'framer-motion';
 import { TypeAnimation } from 'react-type-animation';
 import { heroData } from '@/app/data';
+import ParticleBackground from './ParticleBackground';
 
 export default function HeroSection() {
   const [imageError, setImageError] = useState(false);
@@ -43,6 +44,13 @@ export default function HeroSection() {
     >
       {/* Animated Background Gradients */}
       <div className="absolute inset-0 -z-10 overflow-hidden">
+        {/* Particle Animation */}
+        <ParticleBackground
+          particleCount={40}
+          connectionDistance={120}
+          particleColor="rgba(59, 130, 246, 0.4)"
+          lineColor="rgba(59, 130, 246, 0.1)"
+        />
         {/* Primary gradient orb */}
         <div className="animate-float-gradient absolute -top-40 -right-40 w-80 h-80 sm:w-[500px] sm:h-[500px] rounded-full bg-gradient-to-br from-blue-400/30 to-purple-500/30 dark:from-blue-600/20 dark:to-purple-700/20 blur-3xl" />
         {/* Secondary gradient orb */}

--- a/app/components/ParticleBackground.tsx
+++ b/app/components/ParticleBackground.tsx
@@ -1,0 +1,189 @@
+'use client';
+
+import { useEffect, useRef, useCallback } from 'react';
+import { useReducedMotion } from 'framer-motion';
+
+interface Particle {
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+  radius: number;
+  opacity: number;
+}
+
+interface ParticleBackgroundProps {
+  particleCount?: number;
+  connectionDistance?: number;
+  particleColor?: string;
+  lineColor?: string;
+  className?: string;
+}
+
+export default function ParticleBackground({
+  particleCount = 50,
+  connectionDistance = 150,
+  particleColor = 'rgba(59, 130, 246, 0.5)',
+  lineColor = 'rgba(59, 130, 246, 0.15)',
+  className = '',
+}: ParticleBackgroundProps) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const particlesRef = useRef<Particle[]>([]);
+  const animationRef = useRef<number | null>(null);
+  const prefersReducedMotion = useReducedMotion();
+
+  // Initialize particles
+  const initParticles = useCallback(
+    (width: number, height: number) => {
+      const particles: Particle[] = [];
+      for (let i = 0; i < particleCount; i++) {
+        particles.push({
+          x: Math.random() * width,
+          y: Math.random() * height,
+          vx: (Math.random() - 0.5) * 0.5,
+          vy: (Math.random() - 0.5) * 0.5,
+          radius: Math.random() * 2 + 1,
+          opacity: Math.random() * 0.5 + 0.3,
+        });
+      }
+      particlesRef.current = particles;
+    },
+    [particleCount]
+  );
+
+  // Animation loop
+  const animate = useCallback(
+    (ctx: CanvasRenderingContext2D, width: number, height: number) => {
+      ctx.clearRect(0, 0, width, height);
+
+      const particles = particlesRef.current;
+
+      // Update and draw particles
+      particles.forEach((particle) => {
+        // Update position
+        particle.x += particle.vx;
+        particle.y += particle.vy;
+
+        // Wrap around edges
+        if (particle.x < 0) particle.x = width;
+        if (particle.x > width) particle.x = 0;
+        if (particle.y < 0) particle.y = height;
+        if (particle.y > height) particle.y = 0;
+
+        // Draw particle
+        ctx.beginPath();
+        ctx.arc(particle.x, particle.y, particle.radius, 0, Math.PI * 2);
+        ctx.fillStyle = particleColor;
+        ctx.globalAlpha = particle.opacity;
+        ctx.fill();
+      });
+
+      // Draw connections
+      ctx.globalAlpha = 1;
+      for (let i = 0; i < particles.length; i++) {
+        for (let j = i + 1; j < particles.length; j++) {
+          const dx = particles[i].x - particles[j].x;
+          const dy = particles[i].y - particles[j].y;
+          const distance = Math.sqrt(dx * dx + dy * dy);
+
+          if (distance < connectionDistance) {
+            const opacity = 1 - distance / connectionDistance;
+            ctx.beginPath();
+            ctx.moveTo(particles[i].x, particles[i].y);
+            ctx.lineTo(particles[j].x, particles[j].y);
+            ctx.strokeStyle = lineColor;
+            ctx.globalAlpha = opacity * 0.5;
+            ctx.lineWidth = 1;
+            ctx.stroke();
+          }
+        }
+      }
+
+      animationRef.current = requestAnimationFrame(() => animate(ctx, width, height));
+    },
+    [connectionDistance, particleColor, lineColor]
+  );
+
+  // Setup and cleanup
+  useEffect(() => {
+    if (prefersReducedMotion) return;
+
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    const handleResize = () => {
+      const dpr = window.devicePixelRatio || 1;
+      const rect = canvas.getBoundingClientRect();
+      canvas.width = rect.width * dpr;
+      canvas.height = rect.height * dpr;
+      ctx.scale(dpr, dpr);
+      canvas.style.width = `${rect.width}px`;
+      canvas.style.height = `${rect.height}px`;
+      initParticles(rect.width, rect.height);
+    };
+
+    handleResize();
+    window.addEventListener('resize', handleResize);
+
+    // Start animation
+    animate(ctx, canvas.getBoundingClientRect().width, canvas.getBoundingClientRect().height);
+
+    return () => {
+      window.removeEventListener('resize', handleResize);
+      if (animationRef.current) {
+        cancelAnimationFrame(animationRef.current);
+      }
+    };
+  }, [prefersReducedMotion, initParticles, animate]);
+
+  // Static fallback for reduced motion
+  useEffect(() => {
+    if (!prefersReducedMotion) return;
+
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    const handleResize = () => {
+      const dpr = window.devicePixelRatio || 1;
+      const rect = canvas.getBoundingClientRect();
+      canvas.width = rect.width * dpr;
+      canvas.height = rect.height * dpr;
+      ctx.scale(dpr, dpr);
+      canvas.style.width = `${rect.width}px`;
+      canvas.style.height = `${rect.height}px`;
+
+      // Draw static particles
+      initParticles(rect.width, rect.height);
+      const particles = particlesRef.current;
+
+      particles.forEach((particle) => {
+        ctx.beginPath();
+        ctx.arc(particle.x, particle.y, particle.radius, 0, Math.PI * 2);
+        ctx.fillStyle = particleColor;
+        ctx.globalAlpha = particle.opacity;
+        ctx.fill();
+      });
+    };
+
+    handleResize();
+    window.addEventListener('resize', handleResize);
+
+    return () => {
+      window.removeEventListener('resize', handleResize);
+    };
+  }, [prefersReducedMotion, initParticles, particleColor]);
+
+  return (
+    <canvas
+      ref={canvasRef}
+      className={`absolute inset-0 pointer-events-none ${className}`}
+      aria-hidden="true"
+    />
+  );
+}


### PR DESCRIPTION
## Summary
- 新しい `ParticleBackground` コンポーネントを作成
- Canvas API を使用した軽量なパーティクルアニメーション
- HeroSection の背景に追加

## 変更内容

### 新規ファイル: `app/components/ParticleBackground.tsx`
- **Canvas API 使用**: 外部ライブラリに依存せず、軽量な実装
- **パーティクルアニメーション**: ゆっくり移動するパーティクル
- **接続線描画**: 近接するパーティクル間に接続線を描画
- **devicePixelRatio 対応**: 高解像度ディスプレイでも鮮明に表示
- **カスタマイズ可能なプロパティ**:
  - `particleCount`: パーティクル数
  - `connectionDistance`: 接続線の距離閾値
  - `particleColor`: パーティクルの色
  - `lineColor`: 接続線の色
- **Reduced motion 対応**: 静的なパーティクル表示にフォールバック

### `app/components/HeroSection.tsx`
- `ParticleBackground` コンポーネントを背景に追加
- 既存のグラデーションオーブとの調和

## パフォーマンス
- `requestAnimationFrame` によるスムーズなアニメーション
- 適切なパーティクル数（40個）で負荷を抑制
- `pointer-events-none` でクリック操作に影響なし

## Test plan
- [ ] `npm run build` でビルド成功を確認
- [ ] `npm run lint` でリントエラーがないことを確認
- [ ] デスクトップでパーティクルアニメーションが表示されることを確認
- [ ] パーティクル間の接続線が描画されることを確認
- [ ] Reduced motion 設定時に静的表示になることを確認

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)