### PR TITLE
fix: モバイルUX改善（Issue #135, #136, #141, #142）

### DIFF
--- a/app/components/Navigation.tsx
+++ b/app/components/Navigation.tsx
@@ -16,6 +16,18 @@ export default function Navigation() {
     return () => window.removeEventListener('scroll', handleScroll);
   }, []);
 
+  // Issue #136: モバイルメニュー開閉時のbody scroll制御
+  useEffect(() => {
+    if (isMobileMenuOpen) {
+      document.body.style.overflow = 'hidden';
+    } else {
+      document.body.style.overflow = '';
+    }
+    return () => {
+      document.body.style.overflow = '';
+    };
+  }, [isMobileMenuOpen]);
+
   const scrollToSection = (sectionId: string) => {
     const element = document.getElementById(sectionId);
     if (element) {
@@ -98,8 +110,8 @@ export default function Navigation() {
 
       {/* Mobile Menu */}
       {isMobileMenuOpen && (
-        <div className="md:hidden bg-white dark:bg-gray-900 border-t border-gray-200 dark:border-gray-800">
-          <div className="px-2 pt-2 pb-3 space-y-1">
+        <div className="md:hidden bg-white dark:bg-gray-900 border-t border-gray-200 dark:border-gray-800 max-h-[80vh] overflow-y-auto overscroll-contain">
+          <div className="px-2 pt-2 pb-3 space-y-1 pb-[env(safe-area-inset-bottom)]">
             {navItems.map((item) => (
               <button
                 key={item.id}

--- a/app/components/ScrollToTopButton.tsx
+++ b/app/components/ScrollToTopButton.tsx
@@ -25,9 +25,13 @@ export default function ScrollToTopButton() {
         <motion.button
           onClick={scrollToTop}
           aria-label="ページトップへ戻る"
-          className="fixed bottom-8 right-8 p-3 bg-gray-900 dark:bg-white
+          className="fixed p-3 bg-gray-900 dark:bg-white
                      text-white dark:text-gray-900 rounded-full shadow-lg
                      hover:shadow-xl transition-shadow z-50"
+          style={{
+            bottom: 'calc(2rem + env(safe-area-inset-bottom))',
+            right: 'calc(2rem + env(safe-area-inset-right))',
+          }}
           initial={{ opacity: 0, scale: 0.8 }}
           animate={{ opacity: 1, scale: 1 }}
           exit={{ opacity: 0, scale: 0.8 }}

--- a/app/globals.css
+++ b/app/globals.css
@@ -2,6 +2,11 @@
 @tailwind components;
 @tailwind utilities;
 
+/* Issue #142: スムーススクロールのグローバル設定 */
+html {
+  scroll-behavior: smooth;
+}
+
 :root {
   --background: #ffffff;
   --foreground: #171717;
@@ -21,6 +26,24 @@
 body {
   color: var(--foreground);
   background: var(--background);
+  /* Issue #135: セーフエリア対応 */
+  padding-top: env(safe-area-inset-top);
+  padding-right: env(safe-area-inset-right);
+  padding-bottom: env(safe-area-inset-bottom);
+  padding-left: env(safe-area-inset-left);
+}
+
+/* Issue #141: タップハイライト色の設定 */
+button,
+a,
+[role='button'] {
+  -webkit-tap-highlight-color: transparent;
+}
+
+button:active,
+a:active,
+[role='button']:active {
+  opacity: 0.8;
 }
 
 @layer utilities {
@@ -102,6 +125,11 @@ body {
 
 /* Reduce motion for users who prefer it */
 @media (prefers-reduced-motion: reduce) {
+  /* Issue #142: reduced motion時はスムーススクロールを無効化 */
+  html {
+    scroll-behavior: auto;
+  }
+
   *,
   *::before,
   *::after {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from 'next';
+import type { Metadata, Viewport } from 'next';
 import { Noto_Sans_JP } from 'next/font/google';
 import './globals.css';
 import SkipLink from './components/SkipLink';
@@ -16,6 +16,12 @@ const notoSansJP = Noto_Sans_JP({
 });
 
 const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://your-portfolio.vercel.app';
+
+export const viewport: Viewport = {
+  width: 'device-width',
+  initialScale: 1,
+  viewportFit: 'cover',
+};
 
 export const metadata: Metadata = {
   title: 'Portfolio | Yuki Tadokoro',


### PR DESCRIPTION
## Summary

- **Issue #135**: iPhoneのノッチやホームインジケーター領域でコンテンツが隠れないよう、`env(safe-area-inset-*)`を使用したセーフエリア対応を実装
- **Issue #136**: モバイルメニューに`overscroll-behavior: contain`を設定し、メニュー開閉時にbodyスクロールを制御
- **Issue #141**: `-webkit-tap-highlight-color`を意図的に設定し、`:active`状態でフィードバックを提供
- **Issue #142**: `scroll-behavior: smooth`をグローバルに設定し、`prefers-reduced-motion`を尊重

## 変更内容

### layout.tsx
- `Viewport`型をインポート
- `viewportFit: 'cover'`を含むviewport設定を追加

### globals.css
- `html`に`scroll-behavior: smooth`を追加
- `body`にセーフエリア対応のpaddingを追加
- `button`, `a`, `[role='button']`にタップハイライト設定を追加
- `prefers-reduced-motion`時にスムーススクロールを無効化

### Navigation.tsx
- モバイルメニュー開閉時にbodyのoverflowを制御するuseEffectを追加
- モバイルメニューに`max-h-[80vh] overflow-y-auto overscroll-contain`を追加
- モバイルメニュー内にセーフエリア対応のpaddingを追加

### ScrollToTopButton.tsx
- ボタン位置をセーフエリアを考慮した`calc(2rem + env(safe-area-inset-*))`に変更

## Test plan

- [ ] iPhoneでノッチ/Dynamic Island領域にコンテンツが重ならないことを確認
- [ ] モバイルメニュー内をスクロールしても背景がスクロールしないことを確認
- [ ] タップ時にデフォルトの青いハイライトが表示されないことを確認
- [ ] ナビゲーションリンククリック時にスムーススクロールすることを確認
- [ ] `prefers-reduced-motion`有効時にスクロールが即座に行われることを確認

Closes #135, #136, #141, #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)